### PR TITLE
Optimize geometry loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Try it :
 
 [npm package](https://www.npmjs.com/package/volograms-js)
 
+
 ## Install from npm
 
 `npm i volograms-js`
@@ -61,8 +62,16 @@ Need to try https://bundle.run/ or https://wzrd.in/ or https://unpkg.com/
 
 ## Options
 
-- `texture` : The video texture is expected to be named `texture_1024_h264.mp4`, otherwise if it is named for example `texture_2048_h264.mp4` do `new Vologram(url, () => {}, {texture: 'texture_2048_h264.mp4'})`
-- `autoplay` : By default, this is true, but if you don't want to play when loaded: `new Vologram(url, () => {}, {autoplay: false})` 
+Options can be provided in constructor, eg `new Vologram(url, () => {}, {texture: 'texture_2048_h264.mp4'})`
+
+| Key        | Comment                                                               | Default value           |
+|------------|:----------------------------------------------------------------------|:------------------------|
+| `texture`  | Video texture filename                                                | `texture_1024_h264.mp4` |
+| `header`   | Header filename                                                       | `header.vols`           |
+| `sequence` | Sequence filename                                                     | `sequence_0.vols`       |
+| `autoplay` | Autoplay when loaded. Could not work anymore because of Chrome policy | `false`                 |
+| `fps`      | Frames per seconds                                                    | `30`                    |
+
 
 ## Sound & Play/Pause
 
@@ -71,6 +80,14 @@ This lib uses and exposes the standard [`HTMLVideoElement`](https://developer.mo
 - [play](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play): `vologram.elVideo.play()`
 - [unmute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/muted): `vologram.elVideo.muted = false`. Remember that usually playing and unmuted video, needs an user interaction (to avoid annoying him with unwanted sound / advertising)
 - [seek](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime): `vologram.elVideo.currentTime = 1.5`. In seconds
+
+### Difference with official plugin
+
+Volograms released recently their npm plugin [@volograms/web_vol_lib](https://www.npmjs.com/package/@volograms/web_vol_lib)
+
+Differences : 
+- their uses `wasm`, but mine don't, however both should have same performance
+- mine can be used in one line using the constructor `new Vologram()`
 
 ### Troubleshooting
 

--- a/src/BinaryReader.js
+++ b/src/BinaryReader.js
@@ -1,6 +1,20 @@
 // const { IOBuffer } = require('iobuffer') //npm i iobuffer
 //let iobuffer = new IOBuffer(arrayBuffer)
 
+// TODO use https://www.npmjs.com/package/iobuffer?activeTab=readme instead
+
+export const TypedArrays = {
+    int8: Int8Array,
+    uint8: Uint8Array,
+    int16: Int16Array,
+    uint16: Uint16Array,
+    int32: Int32Array,
+    uint32: Uint32Array,
+    uint64: BigUint64Array,
+    int64: BigInt64Array,
+    float32: Float32Array,
+};
+
 export class BinaryReader {
     /** */
     constructor(arrayBuffer) {
@@ -66,9 +80,23 @@ export class BinaryReader {
     //     return view.getFloat32(0, true);
     // }
 
-    readSingle(){
+    readSingle(d){
         let val =  this.dataView.getFloat32(this.cur, true) //see IOBuffer.ts readFloat32
+
         this.cur += 4
+        return val
+    }
+
+
+    /**
+     * @param length in bytes (1 float32 is 4 bytes === 32 bits)
+     // * @returns {Float32Array|}
+     */
+    readArray(length, type = TypedArrays.uint8) {
+        const val = type.BYTES_PER_ELEMENT === 1 || this.cur % type.BYTES_PER_ELEMENT === 0
+            ? new type(this.arrayBuffer, this.cur, length / type.BYTES_PER_ELEMENT) // probably more efficient but can only be used if multiple of type.BYTES_PER_ELEMENT : `Uncaught RangeError: start offset of Float32Array should be a multiple of 4`
+            : new type(this.arrayBuffer.slice(this.cur, this.cur + length))
+        this.cur += length
         return val
     }
 

--- a/src/Vologram.js
+++ b/src/Vologram.js
@@ -3,7 +3,15 @@ import {createElement} from './utils.js'
 import {VologramHeaderReader} from './VologramHeaderReader.js'
 import {VologramBodyReader} from './VologramBodyReader.js'
 
-//VologramFrame.cs AND VologramAssetLoader.cs
+/**
+ * Class loading a vologram in a THREE js project.
+ * It will load the video texture and load/read the frames geometries bin
+ * Basic usage is :
+ * ```
+ * let vologram = new Vologram(url)
+ * scene.add(vologram)
+ * ```
+ */
 export class Vologram extends THREE.Group {
 
     constructor(folder, onProgress = () => {}, options = {}) {
@@ -13,11 +21,11 @@ export class Vologram extends THREE.Group {
             texture: 'texture_1024_h264.mp4',
             header: 'header.vols',
             sequence: 'sequence_0.vols',
+            fps: 30,
             ...options
         }
 
         this.elVideo = createElement(`<video width='400' height='80' muted controls loop playsinline preload='auto' crossorigin='anonymous'>`)
-        this.fps = 30
 
         // elVideo.ontimeupdate is not triggered often enough
         this.elVideo.requestVideoFrameCallback(this.onVideoFrameCallback.bind(this))
@@ -92,7 +100,7 @@ export class Vologram extends THREE.Group {
      * @returns {number}
      */
     getFrameIdx(time) { //eg [0.667-0.700[=20
-        return Math.floor(time * this.fps + 0.0001) //30fps
+        return Math.floor(time * this.options.fps + 0.0001) //30fps
     }
 
     /**

--- a/src/Vologram.js
+++ b/src/Vologram.js
@@ -34,16 +34,11 @@ export class Vologram extends THREE.Group {
         if(this.options.autoplay)
             this.elVideo.play()
 
-        this.material = this.options.debugNormal
-            ? new THREE.MeshNormalMaterial({
-                side: THREE.DoubleSide,
-                flatShading: true
-            })
-            : new THREE.MeshPhongMaterial({
-                side: THREE.DoubleSide,
-                flatShading: true,
-                map: texture,
-            })
+        this.material = new THREE.MeshPhongMaterial({
+            side: THREE.DoubleSide,
+            flatShading: true,
+            map: texture,
+        })
 
         this.bodyReader = await this.fetch(folder)
 
@@ -108,7 +103,6 @@ export class Vologram extends THREE.Group {
     createGeometry(body) {
         let geometry = new THREE.BufferGeometry()
         geometry.setIndex(new THREE.BufferAttribute(body.indicesData, 1))
-        console.log(body, body.verticesData.length)
         geometry.setAttribute('position', new THREE.BufferAttribute(body.verticesData, 3))
         geometry.setAttribute('normal', new THREE.BufferAttribute(body.normalsData, 3))
         geometry.setAttribute('uv', new THREE.BufferAttribute(body.uvsData, 2))

--- a/src/VologramBodyReader.js
+++ b/src/VologramBodyReader.js
@@ -1,7 +1,14 @@
-import * as THREE from "three";
-import { BinaryReader, TypedArrays } from "./BinaryReader.js"
-import {fetchOnProgress} from "./utils.js"
+import { BinaryReader, TypedArrays } from './BinaryReader.js'
+import {fetchOnProgress} from './utils.js'
 
+/**
+ * Class loading and reading a volograms body containing frames/sequence (usually sequence_0.vols)
+ * This version first load and read the whole file skipping the frame data and build a frame directory
+ * containing pointers allowing to access directly a specific frame in memory
+ * Then it will load (copy or if possible only point) the geometry for a given frame number.
+ * It handles skipped keyframe.
+ * Previous version was creating all geometries, which could have caused memory issue when the volograms is big
+ */
 export class VologramBodyReader {
 
     constructor(url, header, onProgress = () => {}) {

--- a/src/VologramBodyReader.js
+++ b/src/VologramBodyReader.js
@@ -1,4 +1,5 @@
-import {BinaryReader} from "./BinaryReader.js"
+import * as THREE from "three";
+import { BinaryReader, TypedArrays } from "./BinaryReader.js"
 import {fetchOnProgress} from "./utils.js"
 
 export class VologramBodyReader {
@@ -8,37 +9,83 @@ export class VologramBodyReader {
         this._version = version
 
         this.frameNumber = -1
-        this.lastKeyFrameNumber = undefined
+        this.lastKeyFrameNumber = undefined //lastKeyFrameLoaded
         this._previousFrame = -1
         this.meshDataSize = undefined
+
         this.keyFrame = undefined
         this._verticesSize = undefined
 
-        this.verticesData = []
-        this.normalsData = []
-        this.indicesData = []
-        this.uvsData = []
-        this.textureData = []
+        /** @type {Float32Array} */
+        this.verticesData = null
+        this.normalsData = null
+        /** @type {Uint16Array} */
+        this.indicesData = null
+        /** @type {Float32Array} */
+        this.uvsData = null
+        this.textureData = null
+
+        this.framesDirectory = {}
 
         this.onProgress = onProgress
     }
 
     isKeyFrame() {
-        return this.keyFrame === 1
+        return this.keyFrame === 1 || this.keyFrame === 2
     }
 
     async fetch() {
         let response = await fetchOnProgress(this._url, this.onProgress)
-        // let response = await fetch(this._url); let arraybuffer = await(response.arrayBuffer())
         return new BinaryReader(response.response)
     }
 
-    customReadNext(reader, hasNormals, textured) {
+    customReadNext(reader, hasNormals, textured, readFrameData = true) {
+        const frameCur = reader.cur
         this.frameNumber = reader.readInt32()
         this.meshDataSize = reader.readInt32()
         this.keyFrame = reader.readByte()
         this.frameHeaderCheck()
-        this.readFrameData(reader, hasNormals, textured)
+
+        if(readFrameData) {
+            this.readKeyFrameDataIfSkipped(reader, hasNormals, textured)
+            this.readFrameData(reader, hasNormals, textured)
+        } else {
+            this.handleFramesDirectory(frameCur, reader.cur)
+            this.skipFrameData(reader)
+        }
+    }
+
+    readKeyFrameDataIfSkipped(reader, hasNormals, textured) { //this is really dirty, need to rework that
+        const frameDirectory = this.framesDirectory[this.frameNumber]
+        if(!this.isKeyFrame() && this.lastKeyFrameNumber !== frameDirectory.lastKeyFrameNumber) {
+            const keyframeDirectory = this.framesDirectory[frameDirectory.lastKeyFrameNumber]
+            const cur = reader.cur
+            reader.cur = keyframeDirectory.frameDataCur
+            this.keyFrame = keyframeDirectory.keyFrame
+            this.readFrameData(reader, hasNormals, textured)
+            this.keyFrame = 0
+            this.lastKeyFrameNumber = keyframeDirectory.frameNumber
+            reader.cur = cur
+        }
+    }
+
+    skipFrameData(reader) {
+        reader.cur += this.meshDataSize + 4 //where is the missing float32?!?
+    }
+
+    handleFramesDirectory(cur, frameDataCur) {
+        if (this.isKeyFrame()) {
+            this.lastKeyFrameNumber = this.frameNumber
+        }
+
+        this.framesDirectory[this.frameNumber] = {
+            cur,
+            frameDataCur,
+            frameNumber: this.frameNumber,
+            meshDataSize: this.meshDataSize,
+            keyFrame: this.keyFrame,
+            lastKeyFrameNumber: this.lastKeyFrameNumber
+        }
     }
 
     ////VologramFrame.cs:ParseBody
@@ -50,7 +97,7 @@ export class VologramBodyReader {
             this.readNormalsData(reader)
 
         // New UVs from that frame
-        if (this.keyFrame === 1 || this.keyFrame === 2) {
+        if (this.isKeyFrame()) {
             this.lastKeyFrameNumber = this.frameNumber
             this.readIndicesData(reader)
             this.readUvsData(reader)
@@ -60,78 +107,50 @@ export class VologramBodyReader {
             this.readTextureData(reader)
 
         this._frameMeshDataSize = reader.readInt32()
-        this.frameDataSizeCheck()
+        // this.frameDataSizeCheck()
     }
 
     readVerticesData(reader) {
         this._verticesSize = reader.readInt32()
-        this.verticesData = []
-        // read Vector3 - 3 float - 3x4=12 byte each Vector3
-        for (let i = 0; i < this._verticesSize / 12; i++) { //probably something more effecient than that
-            this.verticesData.push({
-                x: reader.readSingle(),
-                y: reader.readSingle(),
-                z: reader.readSingle()
-            })
-        }
+        this.verticesData = reader.readArray(this._verticesSize, TypedArrays.float32) // read Vector3 - 3 float - 3x4=12 byte each Vector3
     }
 
     readNormalsData(reader) {
         this._normalSize = reader.readInt32()
         if (this._normalSize <= 0) throw new Error(`Invalid normals length value (${this._normalSize})`)
         if (this._normalSize !== this._verticesSize) throw new Error(`The number of normals (size:${this._normalSize}) does not match the number of vertices (size:${this._verticesSize}`)
-        // for(let i=0;i<this._normalSize/4;i++) this.normalsData.push(reader.readSingle())
-        this.normalsData = []
-        for (let i = 0; i < this._normalSize / 12; i++) {
-            this.normalsData.push({
-                x: reader.readSingle(),
-                y: reader.readSingle(),
-                z: reader.readSingle()
-            })
-        }
+        this.normalsData = reader.readArray(this._normalSize, TypedArrays.float32) // nb items : {x,y,z} * (this._normalSize / 12)
     }
 
     readIndicesData(reader) {
         this._indicesSize = reader.readInt32()
         if (this._indicesSize <= 0) throw new Error(`Invalid indices length value (${this._indicesSize})`)
-        this.indicesData = []
+        this.indicesData = null
 
         let verticesCount = this._verticesSize / 4
         if (verticesCount / 3 < 65535) {
             this.usingShortIndices = true
-            for (let i = 0; i < this._indicesSize / 2; i++) { //2=SIZE_C_SHORT
-                this.indicesData.push(reader.readShort()) //this.indicesDataS
-            }
+            this.indicesData = reader.readArray(this._indicesSize, TypedArrays.uint16) //2=SIZE_C_SHORT
         } else {
             this.usingShortIndices = false
-            for (let i = 0; i < this._indicesSize / 4; i++) { //4=SIZE_C_INT
-                this.indicesData.push(reader.readInt32())
-            }
+            this.indicesData = reader.readArray(this._indicesSize, TypedArrays.uint32) //4=SIZE_C_INT
         }
     }
 
     readUvsData(reader) {
-        this._uvsSize = reader.readInt32()
+        this._uvsSize = reader.readInt32() //size in bytes
         if (this._uvsSize <= 0) throw new Error("Invalid uvs length value (" + this._uvsSize + ")")
         if (this._uvsSize / 2 !== this._verticesSize / 3) throw new Error(`The number of UVs does not match the number of vertices: ${this._uvsSize}(_uvsSize)/2 !== ${this._verticesSize}(_verticesSize)/3`)
-        this.uvsData = []
 
-        for (let i = 0; i < this._uvsSize / 8; i++) {
-            this.uvsData.push({
-                x: reader.readSingle(),
-                y: reader.readSingle()
-            })
-        }
+        this.uvsData = reader.readArray(this._uvsSize, TypedArrays.float32)
     }
 
-    readTextureData(reader) { //TODO try it!
+    readTextureData(reader) { //TODO try it, current vols file; do not contains texture
         this._textureSize = reader.readInt32()
         this.textureData = []
 
         if (this._textureSize <= 0) throw new Error(`Invalid texture size value (${this._textureSize})`)
-        for (let i = 0; i < this._textureSize; i++) {
-            this.textureData.push(reader.readByte())
-        }
+        this.textureData = reader.readArray(this._textureSize, TypedArrays.uint8)
     }
 
     frameHeaderCheck() {

--- a/src/VologramBodyReader.js
+++ b/src/VologramBodyReader.js
@@ -63,7 +63,6 @@ export class VologramBodyReader {
             }
 
         }
-        console.log(this.framesDirectory)
     }
 
     /**

--- a/src/VologramHeaderReader.js
+++ b/src/VologramHeaderReader.js
@@ -1,6 +1,8 @@
-import {BinaryReader} from "./BinaryReader.js"
+import {BinaryReader} from './BinaryReader.js'
 
-// VologramHeaderReader.cs
+/**
+ * Class loading and reading a volograms header (usually header.vols)
+ */
 export class VologramHeaderReader {
 
     async init(url) { //asynced constructor

--- a/src/demo.js
+++ b/src/demo.js
@@ -26,8 +26,16 @@ const updateLoading = p => {
     el.innerText = Math.round(p*100) + '%'
 }
 
+// Play/Pause button and Sound/Mute button
 document.getElementById('playpause').onclick = e => vologram.elVideo.paused ? vologram.elVideo.play() : vologram.elVideo.pause()
 document.getElementById('sound').onclick = e => vologram.elVideo.muted = !vologram.elVideo.muted
+
+// Play and unmute when clicking on canvas (because of Chrome policy; can be autoplay)
+renderer.domElement.onclick = e => {
+    vologram.elVideo.play()
+    vologram.elVideo.muted = false
+    renderer.domElement.onclick = null
+}
 
 let url = 'https://www.metalograms.com/ftp/vv/volograms/1670754904327_ld'
 let vologram = new Vologram(url, updateLoading)

--- a/src/demo.js
+++ b/src/demo.js
@@ -24,18 +24,21 @@ scene.add(new THREE.GridHelper(10, 10))
 const updateLoading = p => {
     const el = document.getElementById('loading')
     el.innerText = Math.round(p*100) + '%'
+
+    if(p === 1.0) { //when loaded/100%
+        // Play and unmute when clicking on canvas (because of Chrome policy; cannot be autoplay)
+        renderer.domElement.onclick = e => {
+            vologram.elVideo.play()
+            vologram.elVideo.muted = false
+            renderer.domElement.onclick = null
+        }
+    }
 }
 
 // Play/Pause button and Sound/Mute button
 document.getElementById('playpause').onclick = e => vologram.elVideo.paused ? vologram.elVideo.play() : vologram.elVideo.pause()
 document.getElementById('sound').onclick = e => vologram.elVideo.muted = !vologram.elVideo.muted
 
-// Play and unmute when clicking on canvas (because of Chrome policy; can be autoplay)
-renderer.domElement.onclick = e => {
-    vologram.elVideo.play()
-    vologram.elVideo.muted = false
-    renderer.domElement.onclick = null
-}
 
 let url = 'https://www.metalograms.com/ftp/vv/volograms/1670754904327_ld'
 let vologram = new Vologram(url, updateLoading)

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,6 +16,5 @@ export function fetchOnProgress(url, onProgress, responseType = 'arraybuffer') {
         xhr.addEventListener('abort', () => reject(xhr))
         xhr.open('GET', url)
         xhr.send()
-        window.XHR = xhr
     })
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -17,7 +17,7 @@ module.exports = {
     static: './dist',
     compress: true,
     https: true,
-    port: 9000,
+    // port: 9000,
     hot: true,
     host: '0.0.0.0',
     // disableHostCheck: true,


### PR DESCRIPTION
Do not pre create all the geometries but live create them instead. And do not create unnecessary structure data / copies to speed up the live creation (should be done in less than 1/30s). See `BinaryArray.readArray`